### PR TITLE
Fix logo image size calculation

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Abstract.php
+++ b/app/code/community/FireGento/Pdf/Model/Abstract.php
@@ -121,31 +121,23 @@ abstract class FireGento_Pdf_Model_Abstract extends Mage_Sales_Model_Order_Pdf_A
         if ($image and file_exists(Mage::getBaseDir('media', $store) . '/sales/store/logo/' . $image)) {
             $image = Mage::getBaseDir('media', $store) . '/sales/store/logo/' . $image;
 
-            $size = getimagesize($image);
-
-            $width = $size[0];
-            $height = $size[1];
-
-            if ($width > $height) {
-                $ratio = $width / $height;
-            }
-            elseif ($height > $width) {
-                $ratio = $height / $width;
-            }
-            else {
-                $ratio = 1;
-            }
+            list($width, $height) = getimagesize($image);
 
             if ($height > $maxheight or $width > $maxwidth) {
-                if ($height > $maxheight) {
-                    $height = $maxheight;
-                    $width = round($maxheight * $ratio);
+                // calculate max variance to match dimensions
+                $widthVar = $width / $maxwidth;
+                $heightVar = $height / $maxheight;
+
+                // calculate scale factor to match dimensions
+                if ($widthVar > $heightVar) {
+                    $scale = $maxwidth / $width;
+                } else {
+                    $scale = $maxheight / $height;
                 }
 
-                if ($width > $maxwidth) {
-                    $width = $maxwidth;
-                    $height = round($maxwidth * $ratio);
-                }
+                // calculate new dimensions
+                $height = round($height * $scale);
+                $width  = round($width * $scale);
             }
 
             if (is_file($image)) {


### PR DESCRIPTION
As reported in #27, in some cases the logo will not be displayed on the PDF-printout. This is caused by a miscalculation of the new image dimensions.

Instead of using the image ratio, I calculated the scale factor for the dimension that needs to be reduced most in order to match the max width and height.

Apart from that, I set the maximum image width to the page width. I understand why the height needs to be reduced but I see no reason to prohibit a full size banner on top of the page.
