### PR TITLE
Allow to print creditmemos with no items

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Abstract.php
+++ b/app/code/community/FireGento/Pdf/Model/Abstract.php
@@ -308,6 +308,7 @@ abstract class FireGento_Pdf_Model_Abstract extends Mage_Sales_Model_Order_Pdf_A
         
         $groupedTax = array();
 
+        $items['items'] = array();
         foreach ($source->getAllItems() as $item) {
             if ($item->getOrderItem()->getParentItem()) {
                 continue;


### PR DESCRIPTION
It is possible that creditmemos have no order items. Currently, if there are no order items, the following call to array_push will fail since it expects an array as first parameter:

```
array_push($items['items'], array(
    'row_invoiced'     => $order->getShippingInvoiced(),
    'tax_inc_subtotal' => false,
    'tax_percent'      => $shippingTaxRate,
    'tax_amount'       => $shippingTaxAmount
));
```
