### PR TITLE
Minor fixes in totals display

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Abstract.php
+++ b/app/code/community/FireGento/Pdf/Model/Abstract.php
@@ -659,7 +659,7 @@ abstract class FireGento_Pdf_Model_Abstract extends Mage_Sales_Model_Order_Pdf_A
                             array(
                                 'text'      => $label,
                                 'feed'      => $this->margin['left'] + 320,
-                                'align'     => 'right',
+                                'align'     => 'left',
                                 'font_size' => $fontSize,
                                 'font'      => $fontWeight
                             ),


### PR DESCRIPTION
This pull request fixes the indent of default totals and takes into consideration the `display_zero` setting from the `Mage_Sales` config.xml file for the shipping amount (downloadables, virtual products).
