### PR TITLE
Fixed bug that wrong tax rate is used on invoice printing

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Abstract.php
+++ b/app/code/community/FireGento/Pdf/Model/Abstract.php
@@ -331,7 +331,9 @@ abstract class FireGento_Pdf_Model_Abstract extends Mage_Sales_Model_Order_Pdf_A
             if (!isset($item['row_invoiced'])) $item['row_invoiced'] = 0;
             if (!isset($item['price'])) $item['price'] = 0;
             if (!isset($item['tax_inc_subtotal'])) $item['tax_inc_subtotal'] = 0;
-            if (((float)$item['tax_amount'] > 0)&&((float)$item['row_invoiced'] > 0)) {
+            if (isset($item['tax_percent']) && !empty($item['tax_percent'])) {
+                $_percent = (int)$item['tax_percent'];
+            } else if (((float)$item['tax_amount'] > 0)&&((float)$item['row_invoiced'] > 0)) {
                 $_percent = round((float)$item['tax_amount'] / ((float)$item['row_invoiced'] - (float)$item['discount_invoiced']) * 100,0);
             }
             if (!array_key_exists('tax_inc_subtotal', $item) || $item['tax_inc_subtotal']) {


### PR DESCRIPTION
To reproduce the bug, you create a cart price rule which reduces the cost if your payment type is bank payment by 3%.
Then the tax rate is miscalculated at the item (it becomes 18% instead of 19%) and thus the invoice printing is wrong.
To avoid this, I take the tax rate which is set at the item (if set) and calculate it on the fly only if it is not set.
See screenshot for the invoice problem.
![invoice-wrong-tax-rate-with-cart-rule](https://f.cloud.github.com/assets/4135790/430743/9a73f616-ae75-11e2-8281-c04a61702493.jpg)
