### PR TITLE
_prepareText() on Footer Address

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Engine/Abstract.php
+++ b/app/code/community/FireGento/Pdf/Model/Engine/Abstract.php
@@ -707,14 +707,15 @@ abstract class FireGento_Pdf_Model_Engine_Abstract extends Mage_Sales_Model_Orde
      */
     protected function _insertFooterAddress(&$page, $store = null)
     {
-		$fontSize = 7;
-		$font = $this->_setFontRegular($page, $fontSize);
+        $fontSize = 7;
+        $font = $this->_setFontRegular($page, $fontSize);
+        $y = $this->y;
 
-		$company_first = $this->_prepareText($this->imprint['company_first'], $page, $font, $fontSize, 90);
+        $company_first = $this->_prepareText($this->imprint['company_first'], $page, $font, $fontSize, 90);
         $address = $company_first . "\n";
 
         if (array_key_exists('company_second', $this->imprint)) {
-			$company_second = $this->_prepareText($this->imprint['company_second'], $page, $font, $fontSize, 90);
+            $company_second = $this->_prepareText($this->imprint['company_second'], $page, $font, $fontSize, 90);
             $address .= $company_second . "\n";
         }
 
@@ -722,8 +723,6 @@ abstract class FireGento_Pdf_Model_Engine_Abstract extends Mage_Sales_Model_Orde
         $address .= $this->imprint['zip'] . " ";
         $address .= $this->imprint['city'] . "\n";
 
-        $this->_setFontRegular($page, 7);
-        $y = $this->y;
         foreach (explode("\n", $address) as $value) {
             if ($value !== '') {
                 $page->drawText(trim(strip_tags($value)), $this->margin['left'] - 20, $y, $this->encoding);


### PR DESCRIPTION
The method _prepareText() is now also called for company_first and company_second in the footer. So the company fields can't get to long.
