### PR TITLE
Iban column width

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Engine/Abstract.php
+++ b/app/code/community/FireGento/Pdf/Model/Engine/Abstract.php
@@ -647,7 +647,7 @@ abstract class FireGento_Pdf_Model_Engine_Abstract extends Mage_Sales_Model_Orde
             'swift' => Mage::helper('firegento_pdf')->__('SWIFT:'),
             'iban' => Mage::helper('firegento_pdf')->__('IBAN:')
         );
-        $this->_insertFooterBlock($page, $fields, 215, 50, 140);
+        $this->_insertFooterBlock($page, $fields, 215, 50, 150);
 
         $fields = array(
             'tax_number' => Mage::helper('firegento_pdf')->__('Tax number:'),
@@ -655,7 +655,7 @@ abstract class FireGento_Pdf_Model_Engine_Abstract extends Mage_Sales_Model_Orde
             'register_number' => Mage::helper('firegento_pdf')->__('Register number:'),
             'ceo' => Mage::helper('firegento_pdf')->__('CEO:')
         );
-        $this->_insertFooterBlock($page, $fields, 355, 60, $this->margin['right'] - 355 - 10);
+        $this->_insertFooterBlock($page, $fields, 355, 60, $this->margin['right'] - 365 - 10);
     }
 
     /**


### PR DESCRIPTION
I've made the column where the IBAN number resides a little bit wider because IBAN numbers in the UK are a lot wider.

Example UK IBAN number: `GB59MIDL40021311791907`
