### PR TITLE
Fix for tax display in case of any discounts applied

### DIFF
--- a/src/app/code/community/FireGento/Pdf/Model/Items/Default.php
+++ b/src/app/code/community/FireGento/Pdf/Model/Items/Default.php
@@ -117,7 +117,7 @@ class FireGento_Pdf_Model_Items_Default extends Mage_Sales_Model_Order_Pdf_Items
 
         // prepare tax
         $columns['tax'] = array(
-            'text'      => $order->formatPriceTxt($item->getTaxAmount()),
+            'text'      => $order->formatPriceTxt($item->getTaxAmount() + $item->getHiddenTaxAmount()),
             'align'     => 'right',
             'font_size' => $fontSize,
             '_width'    => 50
@@ -133,7 +133,7 @@ class FireGento_Pdf_Model_Items_Default extends Mage_Sales_Model_Order_Pdf_Items
 
         // prepare subtotal
         $columns['subtotal'] = array(
-            'text'      => $order->formatPriceTxt($item->getPrice() * $item->getQty() * 1),
+            'text'      => $order->formatPriceTxt($item->getRowTotal()),
             'align'     => 'right',
             'font_size' => $fontSize,
             '_width'    => 50
@@ -141,7 +141,7 @@ class FireGento_Pdf_Model_Items_Default extends Mage_Sales_Model_Order_Pdf_Items
 
         // prepare subtotal_incl_tax
         $columns['subtotal_incl_tax'] = array(
-            'text'      => $order->formatPriceTxt(($item->getPrice() * $item->getQty() * 1) + $item->getTaxAmount()),
+            'text'      => $order->formatPriceTxt($item->getRowTotalInclTax()),
             'align'     => 'right',
             'font_size' => $fontSize,
             '_width'    => 70


### PR DESCRIPTION
The hidden tax amount was missing for the subtotal_incl_tax and tax display of each row. The subtotal was correct but has been changed to also use row_total like subtotal_incl_tax uses row_total_incl_tax.
