### PR TITLE
fix number format of magento with black magic (regex)

### DIFF
--- a/src/app/code/community/FireGento/Pdf/Model/Engine/Abstract.php
+++ b/src/app/code/community/FireGento/Pdf/Model/Engine/Abstract.php
@@ -1129,7 +1129,7 @@ abstract class FireGento_Pdf_Model_Engine_Abstract extends Mage_Sales_Model_Orde
     private function fixNumberFormat($label)
     {
         $pattern = "/(.*)\((\d{1,2}\.\d{4}%)\)/";
-        if (preg_match("$pattern", $label, $matches)) {
+        if (preg_match($pattern, $label, $matches)) {
             $percentage = Zend_Locale_Format::toNumber(
                 $matches[2],
                 array(


### PR DESCRIPTION
fixes #101 with black magic aka regex. I don't see another solution (alternative is to rewrite the core)
