### PR TITLE
customer friendly filenames

### DIFF
--- a/src/app/code/community/FireGento/Pdf/controllers/Adminhtml/Sales/Order/CreditmemoController.php
+++ b/src/app/code/community/FireGento/Pdf/controllers/Adminhtml/Sales/Order/CreditmemoController.php
@@ -1,0 +1,29 @@
+<?php
+
+require('Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php');
+
+class FireGento_Pdf_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Sales_Order_CreditmemoController
+{
+
+    /**
+     * Create pdf for current creditmemo
+     */
+    public function printAction()
+    {
+        $this->_initCreditmemo();
+        /** @see Mage_Adminhtml_Sales_Order_InvoiceController */
+        if ($creditmemoId = $this->getRequest()->getParam('creditmemo_id')) {
+            if ($creditmemo = Mage::getModel('sales/order_creditmemo')->load($creditmemoId)) {
+                $pdf = Mage::getModel('sales/order_pdf_creditmemo')->getPdf(array($creditmemo));
+                $this->_prepareDownloadResponse(
+                    Mage::helper('firegento_pdf')->getExportFilename('creditmemo', $creditmemo),
+                    $pdf->render(), 'application/pdf'
+                );
+            }
+        }
+        else {
+            $this->_forward('noRoute');
+        }
+    }
+
+}

--- a/src/app/code/community/FireGento/Pdf/controllers/Adminhtml/Sales/Order/InvoiceController.php
+++ b/src/app/code/community/FireGento/Pdf/controllers/Adminhtml/Sales/Order/InvoiceController.php
@@ -1,0 +1,28 @@
+<?php
+
+require('Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php');
+
+class FireGento_Pdf_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Sales_Order_InvoiceController
+{
+
+    /**
+     * Create pdf for current invoice
+     */
+    public function printAction()
+    {
+        $this->_initInvoice();
+        if ($invoiceId = $this->getRequest()->getParam('invoice_id')) {
+            if ($invoice = Mage::getModel('sales/order_invoice')->load($invoiceId)) {
+                $order = $invoice->getOrder();
+                $pdf = Mage::getModel('sales/order_pdf_invoice')->getPdf(array($invoice));
+                $this->_prepareDownloadResponse(
+                    Mage::helper('firegento_pdf')->getExportFilename('invoice', $invoice),
+                    $pdf->render(), 'application/pdf'
+                );
+            }
+        } else {
+            $this->_forward('noRoute');
+        }
+    }
+
+}

--- a/src/app/code/community/FireGento/Pdf/controllers/Adminhtml/Sales/Order/ShipmentController.php
+++ b/src/app/code/community/FireGento/Pdf/controllers/Adminhtml/Sales/Order/ShipmentController.php
@@ -1,0 +1,25 @@
+<?php
+
+require('Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php');
+
+class FireGento_Pdf_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Sales_Order_ShipmentController
+{
+
+    public function printAction()
+    {
+        /** @see Mage_Adminhtml_Sales_Order_InvoiceController */
+        if ($shipmentId = $this->getRequest()->getParam('invoice_id')) { // invoice_id o_0
+            if ($shipment = Mage::getModel('sales/order_shipment')->load($shipmentId)) {
+                $pdf = Mage::getModel('sales/order_pdf_shipment')->getPdf(array($shipment));
+                $this->_prepareDownloadResponse(
+                    Mage::helper('firegento_pdf')->getExportFilename('shipment', $shipment),
+                    $pdf->render(), 'application/pdf'
+                );
+            }
+        }
+        else {
+            $this->_forward('noRoute');
+        }
+    }
+
+}

--- a/src/app/code/community/FireGento/Pdf/controllers/Sales/OrderController.php
+++ b/src/app/code/community/FireGento/Pdf/controllers/Sales/OrderController.php
@@ -123,7 +123,7 @@ class FireGento_Pdf_Sales_OrderController extends Mage_Sales_OrderController
             $pdfGenerator = Mage::getModel('sales/order_pdf_' . $type);
             $pdf = $pdfGenerator->getPdf($documentsCollection);
             $this->_prepareDownloadResponse(
-                Mage::helper('firegento_pdf')->getExportFilename($type, $order), $pdf->render(), 'application/pdf'
+                Mage::helper('firegento_pdf')->getExportFilename($type, $document), $pdf->render(), 'application/pdf'
             );
 
             // Restore area.

--- a/src/app/code/community/FireGento/Pdf/etc/config.xml
+++ b/src/app/code/community/FireGento/Pdf/etc/config.xml
@@ -106,6 +106,17 @@
             </modules>
         </translate>
     </adminhtml>
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <firegento_pdf before="Mage_Adminhtml">FireGento_Pdf_Adminhtml</firegento_pdf>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+    </admin>
     <phpunit>
         <suite>
             <modules>
@@ -116,7 +127,7 @@
     <default>
         <sales_pdf>
             <invoice>
-                <engine />
+                <engine/>
                 <show_customer_number>1</show_customer_number>
                 <show_date_notice>0</show_date_notice>
                 <maturity/>
@@ -128,14 +139,14 @@
                 <show_item_discount>0</show_item_discount>
             </invoice>
             <shipment>
-                <engine />
+                <engine/>
                 <show_customer_number>1</show_customer_number>
                 <shipping_method_position/>
                 <note/>
                 <order_id_as_barcode>0</order_id_as_barcode>
             </shipment>
             <creditmemo>
-                <engine />
+                <engine/>
                 <show_customer_number>1</show_customer_number>
                 <note/>
             </creditmemo>

--- a/src/app/code/community/FireGento/Pdf/etc/system.xml
+++ b/src/app/code/community/FireGento/Pdf/etc/system.xml
@@ -153,7 +153,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <comment>available placeholders: {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"</comment>
+                            <comment>available placeholders: {{invoice_id}}, {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"</comment>
                         </filename_export_pattern>
                     </fields>
                 </invoice>
@@ -213,7 +213,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <comment>available placeholders: {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"</comment>
+                            <comment>available placeholders: {{shipment_id}}, {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"</comment>
                         </filename_export_pattern>
                     </fields>
                 </shipment>
@@ -253,7 +253,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <comment>available placeholders: {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"</comment>
+                            <comment>available placeholders: {{creditmemo_id}}, {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"</comment>
                         </filename_export_pattern>
                     </fields>
                 </creditmemo>


### PR DESCRIPTION
adds the possibility to export all PDFs with filenames based on patterns. Possible Patterns are: {{order_id}}, {{customer_id}}, {{customer_name}}, {{customer_firstname}}, {{customer_lastname}} and strftime() date formats like "%Y"
does a lot of things for #110, but only for the frontend. Backend needs to be fixed
