### PR TITLE
reduce barcode size

### DIFF
--- a/src/app/code/community/FireGento/Pdf/Model/Observer.php
+++ b/src/app/code/community/FireGento/Pdf/Model/Observer.php
@@ -287,11 +287,12 @@ class FireGento_Pdf_Model_Observer
         $barcodeConfig = array(
             'drawText' => false,
             'orientation' => 90,
+            'barHeight' => 25,
             'text' => $order->getIncrementId()
         );
         $rendererConfig = array(
             'verticalPosition' => 'middle',
-            'moduleSize' => 0.9
+            'moduleSize' => 1
         );
         // create dummy Zend_Pdf object, which just stores the current page, so that we can pass it in
         // Zend_Barcode_Renderer_Pdf->setResource()


### PR DESCRIPTION
The barcodes are way too huge for my taste. Their height is the maximum of space between the table and the page border. I reduced the height from the default (50) to 25. I also upped the moduleSize to 1 making the code a bit easier to scan.

Reducing height of a barcode should never be a problem, so this just gives the page a cleaner look (I'm using the barcode on the invoice, so that matters ;-)).