### PR TITLE
reposition barcode for better reach

### DIFF
--- a/src/app/code/community/FireGento/Pdf/Model/Observer.php
+++ b/src/app/code/community/FireGento/Pdf/Model/Observer.php
@@ -320,7 +320,7 @@ class FireGento_Pdf_Model_Observer
             'text' => $order->getIncrementId()
         );
         $rendererConfig = array(
-            'verticalPosition' => 'middle',
+            'verticalPosition' => 'top',
             'moduleSize' => 1
         );
         // create dummy Zend_Pdf object, which just stores the current page, so that we can pass it in


### PR DESCRIPTION
Invoices or packing slips are usually folded. So the barcode will be either hidden or have the fold go through it. Lets position it at the top-right, right?