### PR TITLE
[~BUGFIX] added top margin for barcode

### DIFF
--- a/src/app/code/community/FireGento/Pdf/Model/Observer.php
+++ b/src/app/code/community/FireGento/Pdf/Model/Observer.php
@@ -332,6 +332,7 @@ class FireGento_Pdf_Model_Observer
         // calculate left offset so that barcode is printed on the right with a little margin
         $leftOffset = $page->getWidth() - $renderer->getBarcode()->getWidth(true) * $renderer->getModuleSize() - 10;
         $renderer->setLeftOffset($leftOffset);
+        $renderer->setTopOffset(50);
         $renderer->draw();
         return $this;
     }


### PR DESCRIPTION
In some tests, two out of five printers would cut a little off the barcode now that it was positioned at the top. Added a little spacing.