### PR TITLE
Added check for valid countryNotes value

### DIFF
--- a/src/app/code/community/FireGento/Pdf/Helper/Invoice.php
+++ b/src/app/code/community/FireGento/Pdf/Helper/Invoice.php
@@ -41,15 +41,16 @@ class FireGento_Pdf_Helper_Invoice extends Mage_Core_Helper_Abstract
         if (!$order->getIsVirtual()) {
             $shippingCountryId = $order->getShippingAddress()->getCountryId();
             $countryNotes = unserialize(Mage::getStoreConfig('sales_pdf/invoice/shipping_country_notes'));
-
-            $shippingCountryNotes = array();
-            foreach ($countryNotes as $countryNote) {
-                if ($countryNote['country'] == $shippingCountryId) {
-                    $shippingCountryNotes[] = $countryNote['note'];
+            if($countryNotes) {
+                $shippingCountryNotes = array();
+                foreach ($countryNotes as $countryNote) {
+                    if ($countryNote['country'] == $shippingCountryId) {
+                        $shippingCountryNotes[] = $countryNote['note'];
+                    }
                 }
-            }
 
-            return $shippingCountryNotes;
+                return $shippingCountryNotes;
+            }
         }
 
         return array();


### PR DESCRIPTION
Solves Warning: Invalid argument supplied for foreach()  in /src/vendor/firegento/pdf/src/app/code/community/FireGento/Pdf/Helper/Invoice.php on line 47
#0 /src/vendor/firegento/pdf/src/app/code/community/FireGento/Pdf/Helper/Invoice.php(47): mageCoreErrorHandler(2, 'Invalid argumen...', '/var/www/projec...', 47, Array)

$countryNotes returnes bool false if value is not set.